### PR TITLE
ManualControl: Only save arm switch state when arming is valid

### DIFF
--- a/flight/Libraries/inc/sanitycheck.h
+++ b/flight/Libraries/inc/sanitycheck.h
@@ -32,6 +32,13 @@
 extern int32_t configuration_check();
 void set_config_error(SystemAlarmsConfigErrorOptions error_code);
 
+/**
+ * @brief Checks if we can safely arm in the given flight mode
+ * @param[in] flight_mode The flight mode to check
+ * @retval true if arming is safe, false otherwise
+ */
+bool can_arm_in_mode(uint8_t flight_mode);
+
 #endif /* SANITYCHECK_H */
 
 /**

--- a/flight/Modules/ManualControl/inc/transmitter_control.h
+++ b/flight/Modules/ManualControl/inc/transmitter_control.h
@@ -101,7 +101,7 @@ int32_t transmitter_control_update();
 int32_t transmitter_control_select(bool reset_controller);
 
 //! Query what the flight mode _would_ be if this is selected
-uint8_t transmitter_control_get_flight_mode();
+uint8_t transmitter_control_get_flight_mode(float flight_mode_value);
 
 //! Get any control events
 enum control_events transmitter_control_get_events();

--- a/flight/Modules/ManualControl/manualcontrol.c
+++ b/flight/Modules/ManualControl/manualcontrol.c
@@ -40,6 +40,7 @@
 
 #include "pios_thread.h"
 #include "pios_rcvr.h"
+#include "sanitycheck.h"
 
 #include "control.h"
 #include "failsafe_control.h"
@@ -294,12 +295,7 @@ bool ok_to_arm(void)
 	uint8_t flight_mode;
 	FlightStatusFlightModeGet(&flight_mode);
 
-	if (flight_mode == FLIGHTSTATUS_FLIGHTMODE_FAILSAFE) {
-		/* Separately mask FAILSAFE arming here. */
-		return false;
-	}
-
-	return true;
+	return can_arm_in_mode(flight_mode);
 }
 
 /**

--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -676,7 +676,11 @@ static void process_transmitter_events(ManualControlCommandData * cmd, ManualCon
 		}
 
 		if (valid && ok_to_arm()) {
-			// Only update arming edge detector on valid rx
+			/* Only update arming edge detector on valid rx and ok_to_arm, to avoid surprise arming
+			 * During boot: ok_to_arm causes arming_position to be false while attitude module is 
+			 *   still starting (it has an error).
+			 * After failsafe: ok_to_arm causes arming_position to be false for one cycle while rx
+			 *   is valid because we are still in failsafe flight mode. */
 			last_arm = arm;
 		}
 	}

--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -682,6 +682,8 @@ static void process_transmitter_events(ManualControlCommandData * cmd, ManualCon
 			 * After failsafe: ok_to_arm causes arming_position to be false for one cycle while rx
 			 *   is valid because we are still in failsafe flight mode. */
 			last_arm = arm;
+		} else {
+			last_arm = true; /* force a toggle of the arm switch */
 		}
 	}
 		break;

--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -675,7 +675,7 @@ static void process_transmitter_events(ManualControlCommandData * cmd, ManualCon
 			arm_state = ARM_STATE_ARMING;
 		}
 
-		if (valid) {
+		if (valid && ok_to_arm()) {
 			// Only update arming edge detector on valid rx
 			last_arm = arm;
 		}


### PR DESCRIPTION
During boot: ok_to_arm causes arming_position to be false while attitude module is still starting (it has an error).
After failsafe: ok_to_arm causes arming_position to be false for one cycle while rx is valid because we are still in failsafe flight mode.
